### PR TITLE
feat(coverage): update coverage settings 

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "ryanluker.vscode-coverage-gutters",
     "bradlc.vscode-tailwindcss",
     "dbaeumer.vscode-eslint",
     "biomejs.biome",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,7 +92,7 @@
     "**/dist/**": true,
     "**/build/**": true,
     "**/.turbo/**": true,
-    "**/coverage/**": true,
+    "**/coverage/**": false,
     "**/.wp_federation/**": true,
     "**/playwright-report/**": true,
     "**/test-results/**": true,
@@ -117,14 +117,14 @@
     "**/build/**": true,
     "**/.turbo": true,
     "**/.turbo/**": true,
-    "**/coverage": true,
-    "**/coverage/**": true,
+    "**/coverage": false,
+    "**/coverage/**": false,
     "**/.wp_federation": true,
     "**/.wp_federation/**": true,
-    "**/playwright-report": true,
-    "**/playwright-report/**": true,
-    "**/test-results": true,
-    "**/test-results/**": true,
+    "**/playwright-report": false,
+    "**/playwright-report/**": false,
+    "**/test-results": false,
+    "**/test-results/**": false,
     "**/.next": true,
     "**/.next/**": true,
     "**/out": true,
@@ -152,7 +152,16 @@
     "serviços",
     "nodenext",
     "Registrator",
-    "rsdoctor", 
+    "rsdoctor",
     "rspack"
-  ]
+  ],
+  // Coverage Gutters: find all MFEs' coverage outputs
+  // Search any coverage folder in the workspace for lcov.info
+  "coverage-gutters.coverageBaseDir": "**/coverage",
+  "coverage-gutters.coverageFileNames": ["lcov.info"],
+  // Start watching automatically when the workspace opens
+  "coverage-gutters.watchOnActivate": true,
+  // Show coverage in the gutter; leave line coverage off for breakpoint compatibility
+  "coverage-gutters.showGutterCoverage": true,
+  "coverage-gutters.showLineCoverage": false
 }

--- a/apps/header-pages/bunfig.toml
+++ b/apps/header-pages/bunfig.toml
@@ -1,5 +1,6 @@
 [test]
 coverage = true
+coverageReporter = [ "text", "lcov", ]
 
 coveragePathIgnorePatterns = [
   "**/@config/**",

--- a/apps/shell/bunfig.toml
+++ b/apps/shell/bunfig.toml
@@ -1,6 +1,7 @@
 [test]
 
 coverage = true
+coverageReporter = [ "text", "lcov", ]
 
 coveragePathIgnorePatterns = [
   "**/@config/**",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -23,6 +23,7 @@ registry = "https://registry.npmjs.org/"
 # Test runner configuration (Bun can run Jest tests)
 # Coverage settings
 coverage = true
+coverageReporter = [ "text", "lcov", ]
 
 # Exclude assets from coverage across the monorepo
 coveragePathIgnorePatterns = [

--- a/millenium-bim-call-center.code-workspace
+++ b/millenium-bim-call-center.code-workspace
@@ -57,7 +57,8 @@
       "**/dist/**": true,
       "**/build/**": true,
       "**/.turbo/**": true,
-      "**/coverage/**": true,
+      // Allow coverage changes to be watched by Coverage Gutters
+      "**/coverage/**": false,
       "**/.wp_federation/**": true,
       "**/playwright-report/**": true,
       "**/test-results/**": true,
@@ -98,10 +99,17 @@
       "**/tmp/**": true,
       "**/temp": true,
       "**/temp/**": true
-    }
+    },
+    // Coverage Gutters: look for lcov.info in any coverage folder and auto-watch on open
+    "coverage-gutters.coverageBaseDir": "**/coverage",
+    "coverage-gutters.coverageFileNames": ["lcov.info"],
+    "coverage-gutters.watchOnActivate": true,
+    "coverage-gutters.showGutterCoverage": true,
+    "coverage-gutters.showLineCoverage": false
   },
   "extensions": {
     "recommendations": [
+      "ryanluker.vscode-coverage-gutters",
       "bradlc.vscode-tailwindcss",
       "biomejs.biome",
       "yoavbls.pretty-ts-errors",

--- a/packages/shared/bunfig.toml
+++ b/packages/shared/bunfig.toml
@@ -1,5 +1,6 @@
 [test]
 coverage = true
+coverageReporter = [ "text", "lcov", ]
 
 coveragePathIgnorePatterns = [
   "**/assets/**",


### PR DESCRIPTION
- configures bun test to export `lcov.info` files
- adds suggested vscode extension to display coverage gutters in the IDE
- using istanbuljs is not effective for this application stack 
- wip: checking `codecov` app to be used for codecoverage